### PR TITLE
migrate to react-hot-loader v4

### DIFF
--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
+import { hot } from 'react-hot-loader';
 
-export default class Main extends Component {
+export default
+@hot(module)
+class Main extends Component {
   render() {
     return (
       <div style={{ textAlign: 'center' }}>

--- a/src/index.js
+++ b/src/index.js
@@ -1,24 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { AppContainer } from 'react-hot-loader';
+import {render} from 'react-dom';
+import Main from './containers';
 
-const render = () => {
-  const Main = require('containers').default;
-
-  ReactDOM.render(
-    <AppContainer>
-      <Main />
-    </AppContainer>,
-    document.getElementById('app')
-  );
-};
-
-render();
-
-// migrate by this guide
-// https://github.com/gaearon/react-hot-loader/tree/master/docs#migration-to-30
-if (module.hot) {
-  module.hot.accept('containers/', () => {
-    render();
-  });
-}
+render(<Main />, document.getElementById('app'));


### PR DESCRIPTION
 react-hot-loader 4 寫法不一樣了，有簡化

## Getting started

1.  Add `react-hot-loader/babel` to your `.babelrc`:

```js
// .babelrc
{
  "plugins": ["react-hot-loader/babel"]
}
```

2.  Mark your root component as _hot-exported_:

```js
// App.js
import React from 'react'
import { hot } from 'react-hot-loader'

const App = () => <div>Hello World!</div>

export default hot(module)(App)
```

3.  [Run webpack with Hot Module Replacement](https://webpack.js.org/guides/hot-module-replacement/#enabling-hmr):

```sh
webpack-dev-server --hot
```